### PR TITLE
chore(release): update release workflow for NPM and GitHub Package Registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,35 +14,24 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=1cpu-linux-arm64
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-      - run: yarn install
-      - run: yarn lint
-      - run: yarn build:all
-      - name: Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: yarn semantic-release
-
-  publish-gpr:
-    needs: release
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-          registry-url: https://npm.pkg.github.com/
-      - run: yarn install
-      - run: yarn build:all
-      - run: yarn publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+        registry-url: 'https://registry.npmjs.org'
+    - run: yarn install
+    - run: yarn lint
+    - run: yarn build:all
+    - run: yarn semantic-release to NPM
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+        registry-url: 'https://npm.pkg.github.com'
+    - run: yarn semantic-release to GitHub Package Registry
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Modified the release job to use a specific runner configuration.
- Consolidated steps for semantic release to publish to both NPM and GitHub Package Registry.
- Updated registry URLs for consistency.