### PR TITLE
`styled-components@6.4.0` refactor breaks `react` in strict mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schematichq/schematic-icons",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "React component library for Schematic's icon system with TypeScript support",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     }
   },
   "dependencies": {
-    "styled-components": "^6.3.11"
+    "styled-components": "6.3.12"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6103,10 +6103,10 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
-styled-components@^6.3.11:
-  version "6.3.11"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-6.3.11.tgz#6babdb151a3419b0a79a368353d1dfbe8c5dddbc"
-  integrity sha512-opzgceGlQ5rdZdGwf9ddLW7EM2F4L7tgsgLn6fFzQ2JgE5EVQ4HZwNkcgB1p8WfOBx1GEZP3fa66ajJmtXhSrA==
+styled-components@6.3.12:
+  version "6.3.12"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-6.3.12.tgz#263a1c52bd1c5d1cdd2667e9605e5ffa8df592d0"
+  integrity sha512-hFR6xsVkVYbsdcUlzPYFvFfoc6o2KlV0VvgRIQwSYMtdThM7SCxnjX9efh/cWce2kTq16I/Kl3xM98xiLptsXA==
   dependencies:
     "@emotion/is-prop-valid" "1.4.0"
     "@emotion/unitless" "0.10.0"


### PR DESCRIPTION
Resulting error:
```
"Rendered fewer hooks than expected"
```

Pin to v6.3.12 until this is fixed.