### PR TITLE
feat: add metronome icon

### DIFF
--- a/src/svg/metronome.svg
+++ b/src/svg/metronome.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M1 3.364h2.75v17.272h-2.75zM5.813 5.971h2.75v9.288h-2.75zM10.625 11.348h2.75v9.288h-2.75zM15.437 7.926h2.75v9.288h-2.75zM20.25 3.364h2.75v17.272h-2.75z" fill="black"/>
+</svg>


### PR DESCRIPTION
Adds an icon for [Metronome](https://metronome.com/). The mark is the 5-bar equalizer/metronome symbol from their wordmark, scaled and centered into a 24×24 viewBox.