### PR TITLE
chore(ci): authenticate npm publish via OIDC trusted publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ permissions:
   issues: write
   pull-requests: write
   packages: write
+  id-token: write
 
 jobs:
   release:
@@ -27,6 +28,4 @@ jobs:
     - name: Release to NPM and GitHub Package Registry
       run: yarn semantic-release
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Switches `release.yml` from a static `NPM_TOKEN` to npm's OIDC trusted-publisher flow. `@semantic-release/npm@13` already prefers OIDC when available — we just need to grant the runner permission to mint a JWT and remove the static token env so the OIDC path is the only one.

**Requires before merging:** `@schematichq/schematic-icons` on npmjs.com must have `SchematicHQ/schematic-icons` `release.yml` configured as a trusted publisher (Settings → Trusted Publisher).

After this lands, the org-level `NPM_TOKEN` secret can be removed — nothing references it.