### PR TITLE
chore(ci): disable npm provenance and release-failure issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,3 +29,6 @@ jobs:
       run: yarn semantic-release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Disable npm provenance attestation: it requires a GitHub-hosted
+        # runner and we use a self-hosted RunsOn runner. OIDC auth still works.
+        NPM_CONFIG_PROVENANCE: "false"

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -15,7 +15,14 @@ export default {
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
     "@semantic-release/npm",
-    "@semantic-release/github",
+    [
+      "@semantic-release/github",
+      {
+        failComment: false,
+        failTitle: false,
+        successComment: false,
+      },
+    ],
     [
       "@semantic-release/git",
       {


### PR DESCRIPTION
Two small noise reductions for the release pipeline.

**`NPM_CONFIG_PROVENANCE=false`**

`npm publish` with provenance requires a GitHub-hosted runner. We use a self-hosted RunsOn runner, so the previous OIDC release attempt published the git tag/release commit but then failed at the npm publish step with `E422 Unsupported GitHub Actions runner environment: "self-hosted"`. Switching runners just for this isn't worth it; OIDC auth via the trusted publisher works fine without provenance.

**`@semantic-release/github` failComment / failTitle / successComment = false**

Stops the plugin from filing "The automated release is failing 🚨" issues on failures and from commenting on every merged PR with "released in version X." The issue creation was already broken anyway (422 from GitHub because the repo has no `semantic-release` label), so this also drops a noisy non-actionable error from the logs.